### PR TITLE
create symbolic link for dynamic lib as well

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -146,5 +146,6 @@ tests:  $(EXTRA_PROGRAMS)
 
 all-local:
 	@ln -sf .libs/libtrurl.a libtrurl.a
+	@ln -sf .libs/libtrurl.so libtrurl.so
 
 include Makefile.extra


### PR DESCRIPTION
both tndb and vfile in poldek link against libtrurl and due to the way
linking is configured it is always linked with static libtrurl (only
libtrurl.a link provided). this causes two issues:

- mixes dynamically linked libraries with statically linked libtrurl
  and since nothing enforces -fPIC in the latter it results in error:

libtool: warning: relinking 'libtndb.la'
libtool: install: ... -o .libs/libtndb.so.0.2.0
/usr/bin/ld: ./../trurlib/libtrurl.a(ndie.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `__stack_chk_guard@@GLIBC_2.17' which may bind externally can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: ./../trurlib/libtrurl.a(ndie.o)(.text+0x8): unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol `__stack_chk_guard@@GLIBC_2.17'
/usr/bin/ld: final link failed: bad value

- includes copy of libtrurl in dynamic libraries even though poldek
  provides dynamic libtrurl